### PR TITLE
Update linuxblueprint.sh

### DIFF
--- a/linuxblueprint.sh
+++ b/linuxblueprint.sh
@@ -57,7 +57,7 @@ if [[ `which apt` ]]; then
    echo " " >> $myoutfile
 
 
-   #Part 1 of Eric' Code
+   #Part 1 of Eric's Code
    
 	echo "************************************************************" >> $myoutfile
 	echo "Installed Packages" >> $myoutfile
@@ -117,7 +117,7 @@ if [[ `which apt` ]]; then
     echo " " >> $myoutfile
 	
     # Part 2 of Eric's Code
-	# Write Section Header
+	
     echo "###################################" >> $myoutfile
     echo "Section 2 - App Armor, SELinux, Syslog/rsyslog" >> $myoutfile
     echo "###################################" >> $myoutfile


### PR DESCRIPTION
Resolved an issue causing errors due to Windows end of line characters in the code.
The error was "$'r\' : command not found" on several lines. To fix this in Notepad++ I used Edit -> Eol Conversion -> Unix (LF) then save the file.